### PR TITLE
Migration to `embedded-hal` v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1.3.2"
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 
 [features]
 i2c = []
@@ -22,5 +22,5 @@ spi = []
 float = []
 
 [dev-dependencies]
-embedded-hal-mock = "0.9.0"
-bma400 = { path = ".", features = ["i2c-default", "spi", "float"]}
+embedded-hal-mock = "0.11.1"
+bma400 = { path = ".", features = ["i2c-default", "spi", "float"] }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,20 +1,8 @@
 use crate::{
-    hal::blocking::i2c::{
-        Write,
-        WriteRead,
-    },
-    interface::{
-        ReadFromRegister,
-        WriteToRegister,
-    },
-    registers::{
-        ChipId,
-        ConfigReg,
-        ReadReg,
-    },
-    BMA400Error,
-    Config,
-    BMA400,
+    hal::i2c::I2c,
+    interface::{ReadFromRegister, WriteToRegister},
+    registers::{ChipId, ConfigReg, ReadReg},
+    BMA400Error, Config, BMA400,
 };
 
 // This is set by the SDO Pin level. (p. 108 of datasheet)
@@ -40,32 +28,40 @@ impl<I2C> I2CInterface<I2C> {
 
 impl<I2C, E> WriteToRegister for I2CInterface<I2C>
 where
-    I2C: Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     type Error = BMA400Error<E, ()>;
 
     fn write_register<T: ConfigReg>(&mut self, register: T) -> Result<(), Self::Error> {
-        self.i2c.write(ADDR, &[register.addr(), register.to_byte()]).map_err(BMA400Error::IOError)
+        self.i2c
+            .write(ADDR, &[register.addr(), register.to_byte()])
+            .map_err(BMA400Error::IOError)
     }
 }
 
 impl<I2C, E> ReadFromRegister for I2CInterface<I2C>
 where
-    I2C: WriteRead<Error = E>,
+    I2C: I2c<Error = E>,
 {
     type Error = BMA400Error<E, ()>;
 
-    fn read_register<T: ReadReg>(&mut self, register: T, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.i2c.write_read(ADDR, &[register.addr()], buffer).map_err(BMA400Error::IOError)
+    fn read_register<T: ReadReg>(
+        &mut self,
+        register: T,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        self.i2c
+            .write_read(ADDR, &[register.addr()], buffer)
+            .map_err(BMA400Error::IOError)
     }
 }
 
 impl<I2C, E> BMA400<I2CInterface<I2C>>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Create a new instance of the BMA400 using I²C
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,4 @@
-use crate::registers::{
-    ConfigReg,
-    ReadReg,
-};
+use crate::registers::{ConfigReg, ReadReg};
 
 pub trait WriteToRegister {
     type Error;
@@ -10,5 +7,9 @@ pub trait WriteToRegister {
 
 pub trait ReadFromRegister {
     type Error;
-    fn read_register<T: ReadReg>(&mut self, register: T, buffer: &mut [u8]) -> Result<(), Self::Error>;
+    fn read_register<T: ReadReg>(
+        &mut self,
+        register: T,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A platform-agnostic driver for the BMA400 accelerometer implemented using [`embedded-hal`] traits.
-//! 
+//!
 //! [`embedded-hal`]: https://crates.io/crates/embedded-hal
-//! 
+//!
 //! # Basic Usage
 //! I²C - `cargo add bma400 --features=i2c-default`
 //! ```
@@ -50,7 +50,7 @@
 //! // csb_pin implements embedded-hal digital::v2::OutputPin
 //! let mut accelerometer = BMA400::new_spi(spi, csb_pin).unwrap();
 //! ```
-//! 
+//!
 //! From here it's the same API for both:
 //! ```
 //! # use embedded_hal_mock::{
@@ -67,8 +67,8 @@
 //! #   Transaction::transfer(vec![0x00], vec![0x00]),
 //! #   Transaction::transfer(vec![0x80, 0x00], vec![0x00, 0x00]),
 //! #   Transaction::transfer(vec![0x00], vec![0x90]),
-//! #   Transaction::write(vec![0x19, 0x02]),
-//! #   Transaction::write(vec![0x1A, 0x09]),
+//! #   Transaction::write_vec(vec![0x19, 0x02]),
+//! #   Transaction::write_vec(vec![0x1A, 0x09]),
 //! #   Transaction::transfer(vec![0x84, 0x00], vec![0x00, 0x00]),
 //! #   Transaction::transfer(
 //! #       vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
@@ -109,7 +109,7 @@
 //! - i2c-alt: Use I²C with the alternate address `0b00010101` with SDO pin pulled to VDDIO[^address]
 //! - spi: Use SPI
 //! - float: Enable functions returning floating point values. Currently just `get_temp_celsius()`
-//! 
+//!
 //! # The Bosch BMA400 Accelerometer
 //! [Datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bma400-ds000.pdf)
 //!
@@ -117,7 +117,7 @@
 //! 12 bit, digital, triaxial acceleration sensor with smart on-chip motion and position-triggered interrupt features.
 //!
 //! Key features
-//! - Small Package Size 
+//! - Small Package Size
 //!   - LGA package (12 pins), footprint 2mm x 2mm, height 0.95 mm
 //! - Ultra-low power
 //!   - Low current consumption of data acquisition without compromising on performance (< 14.5 µA with highest performance)
@@ -135,7 +135,7 @@
 //!   - Tap/double tap
 //! - Digital interface
 //!   - SPI (4-wire, 3-wire)
-//!   - I²C 
+//!   - I²C
 //!   - 2 interrupt pins
 //!   - VDDIO voltage range: 1.2V to 3.6V
 //! - RoHS compliant, halogen-free
@@ -154,32 +154,22 @@
 #![warn(missing_docs, unsafe_code)]
 #![no_std]
 pub(crate) use embedded_hal as hal;
-use hal::blocking::delay::DelayMs;
+use hal::delay::DelayNs;
 pub mod types;
 pub use types::*;
 pub(crate) mod registers;
 use registers::*;
 mod interface;
-use interface::{
-    ReadFromRegister,
-    WriteToRegister,
-};
+use interface::{ReadFromRegister, WriteToRegister};
 mod config;
-use config::{
-    Config,
-};
 pub use config::ActChgConfigBuilder;
+use config::Config;
 pub use config::GenIntConfigBuilder;
 pub use config::OrientChgConfigBuilder;
 pub use config::TapConfigBuilder;
 pub use config::{
-    AccConfigBuilder,
-    AutoLpConfigBuilder,
-    AutoWakeupConfigBuilder,
-    FifoConfigBuilder,
-    IntConfigBuilder,
-    IntPinConfigBuilder,
-    WakeupIntConfigBuilder,
+    AccConfigBuilder, AutoLpConfigBuilder, AutoWakeupConfigBuilder, FifoConfigBuilder,
+    IntConfigBuilder, IntPinConfigBuilder, WakeupIntConfigBuilder,
 };
 
 #[cfg(any(feature = "i2c", test))]
@@ -204,7 +194,7 @@ where
         + WriteToRegister<Error = BMA400Error<InterfaceError, PinError>>,
 {
     /// Returns the chip ID (0x90)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -228,7 +218,7 @@ where
     /// Reads and returns the status of the command error register
     ///
     /// Errors are cleared on read
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -255,7 +245,7 @@ where
     }
 
     /// Reads and returns the sensor [Status] register
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -280,9 +270,9 @@ where
     }
 
     /// Returns a single 3-axis reading as a [Measurement], with no adjustment for the selected [Scale]
-    /// 
+    ///
     /// To get scaled data use [`get_data`](BMA400::get_data)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -300,7 +290,9 @@ where
     /// assert_eq!(8, m.y);     // (16 milli-g)
     /// assert_eq!(494, m.z);   // (988 milli-g)
     /// ```
-    pub fn get_unscaled_data(&mut self) -> Result<Measurement, BMA400Error<InterfaceError, PinError>> {
+    pub fn get_unscaled_data(
+        &mut self,
+    ) -> Result<Measurement, BMA400Error<InterfaceError, PinError>> {
         let mut bytes = [0u8; 6];
         self.interface.read_register(AccXLSB, &mut bytes)?;
         Ok(Measurement::from_bytes_unscaled(&bytes))
@@ -309,7 +301,7 @@ where
     /// Returns a single 3-axis reading as a [Measurement] adjusted for the selected [Scale]
     ///
     /// To get unscaled data use [`get_unscaled_data()`](BMA400::get_unscaled_data)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -339,7 +331,7 @@ where
     /// The lowest 3 bits are always zero (the value is left-justified for compatibility with
     /// 25.6kHz clocks). This timer is inactive in sleep mode. The clock rolls over to zero
     /// after `0xFFFFF8`
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -363,9 +355,9 @@ where
     }
 
     /// Returns `true` if a power reset has been detected
-    /// 
+    ///
     /// Status is cleared when read
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -392,7 +384,7 @@ where
     }
 
     /// Reads and returns the [IntStatus0] interrupt status register
-    /// 
+    ///
     /// - Data Ready Interrupt - [`drdy_stat()`](IntStatus0::drdy_stat)
     /// - FIFO Watermark Interrupt (FIFO watermark surpassed) - [`fwm_stat()`](IntStatus0::fwm_stat)
     /// - FIFO Buffer Full - [`ffull_stat()`](IntStatus0::ffull_stat)
@@ -401,7 +393,7 @@ where
     /// - Generic Interrupt 1 - [`gen1_stat()`](IntStatus0::gen1_stat)
     /// - Orientation Changed - [`orientch_stat()`](IntStatus0::orientch_stat)
     /// - Wakeup Activity Interrupt - [`wkup_stat()`](IntStatus0::wkup_stat)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -426,17 +418,18 @@ where
     /// ```
     pub fn get_int_status0(&mut self) -> Result<IntStatus0, BMA400Error<InterfaceError, PinError>> {
         let mut status_byte = [0u8; 1];
-        self.interface.read_register(InterruptStatus0, &mut status_byte)?;
+        self.interface
+            .read_register(InterruptStatus0, &mut status_byte)?;
         Ok(IntStatus0::new(status_byte[0]))
     }
 
     /// Reads and returns the [IntStatus1] interrupt status register
-    /// 
+    ///
     /// - Interrupt Engine Overrun - [`ieng_overrun_stat()`](IntStatus0::ieng_overrun_stat)
     /// - Double Tap Interrupt - [`d_tap_stat()`](IntStatus1::d_tap_stat)
     /// - Single Tap Interrupt - [`s_tap_stat()`](IntStatus1::s_tap_stat)
     /// - Step Interrupt - [`step_int_stat()`](IntStatus1::step_int_stat)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -461,17 +454,18 @@ where
     /// ```
     pub fn get_int_status1(&mut self) -> Result<IntStatus1, BMA400Error<InterfaceError, PinError>> {
         let mut status_byte = [0u8; 1];
-        self.interface.read_register(InterruptStatus1, &mut status_byte)?;
+        self.interface
+            .read_register(InterruptStatus1, &mut status_byte)?;
         Ok(IntStatus1::new(status_byte[0]))
     }
 
     /// Reads and returns the [IntStatus2] interrupt status register
-    /// 
+    ///
     /// - Interrupt Engine Overrun - [`ieng_overrun_stat()`](IntStatus0::ieng_overrun_stat)
     /// - Activity Change Z - [`actch_z_stat()`](IntStatus2::actch_z_stat)
     /// - Activity Change Y - [`actch_y_stat()`](IntStatus2::actch_y_stat)
     /// - Activity Change X - [`actch_x_stat()`](IntStatus2::actch_x_stat)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -496,12 +490,13 @@ where
     /// ```
     pub fn get_int_status2(&mut self) -> Result<IntStatus2, BMA400Error<InterfaceError, PinError>> {
         let mut status_byte = [0u8; 1];
-        self.interface.read_register(InterruptStatus2, &mut status_byte)?;
+        self.interface
+            .read_register(InterruptStatus2, &mut status_byte)?;
         Ok(IntStatus2::new(status_byte[0]))
     }
 
     /// Returns the number of unread bytes currently in the FIFO
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -524,9 +519,9 @@ where
         Ok(u16::from_le_bytes(bytes))
     }
 
-    /// Reads enough bytes from the FIFO to fill `buffer` and returns a [FifoFrames] iterator 
+    /// Reads enough bytes from the FIFO to fill `buffer` and returns a [FifoFrames] iterator
     /// over the [Frame]s in `buffer`
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -535,9 +530,9 @@ where
     /// # let expected = vec![
     /// #        Transaction::write_read(ADDR, vec![0x00], vec![0x90]),
     /// #        Transaction::write_read(ADDR, vec![0x14], vec![
-    /// #           0x48, 0x6E, 
-    /// #           0x9E, 0x01, 0x80, 0x0F, 0xFF, 0x0F, 0x7F, 
-    /// #           0xA0, 0xF8, 0xFF, 0xFF, 
+    /// #           0x48, 0x6E,
+    /// #           0x9E, 0x01, 0x80, 0x0F, 0xFF, 0x0F, 0x7F,
+    /// #           0xA0, 0xF8, 0xFF, 0xFF,
     /// #           0x80, 0x00]),
     /// #    ];
     /// # let i2c = Mock::new(&expected);
@@ -545,7 +540,7 @@ where
     /// // Read from the FIFO
     /// let mut buffer = [0u8; 15];
     /// let mut frames = bma400.read_fifo_frames(&mut buffer).unwrap();
-    /// 
+    ///
     /// // A Control Frame
     /// if let Some(frame) = frames.next() {
     ///     assert!(matches!(frame.frame_type(), FrameType::Control));
@@ -556,7 +551,7 @@ where
     ///     // This is not a data frame and so has no data
     ///     assert_eq!(None, frame.x());
     /// }
-    /// 
+    ///
     /// // A Data Frame
     /// if let Some(frame) = frames.next() {
     ///     assert!(matches!(frame.frame_type(), FrameType::Data));
@@ -565,17 +560,20 @@ where
     ///     assert_eq!(Some(-1), frame.y());
     ///     assert_eq!(Some(2047), frame.z());
     /// }
-    /// 
+    ///
     /// // A Time Frame
     /// if let Some(frame) = frames.next() {
     ///     assert!(matches!(frame.frame_type(), FrameType::Time));
     ///     assert_eq!(Some(0xFFFFF8), frame.time()); // about to roll over!
     /// }
-    /// 
+    ///
     /// // No more Frames
     /// assert_eq!(None, frames.next());
     /// ```
-    pub fn read_fifo_frames<'a>(&mut self, buffer: &'a mut [u8]) -> Result<FifoFrames<'a>, BMA400Error<InterfaceError, PinError>> {
+    pub fn read_fifo_frames<'a>(
+        &mut self,
+        buffer: &'a mut [u8],
+    ) -> Result<FifoFrames<'a>, BMA400Error<InterfaceError, PinError>> {
         if self.config.is_fifo_read_disabled() {
             return Err(ConfigError::FifoReadWhilePwrDisable.into());
         }
@@ -584,7 +582,7 @@ where
     }
 
     /// Flush all data from the FIFO
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -614,7 +612,7 @@ where
     /// Get the step count
     ///
     /// The counter only increments if the Step Interrupt is enabled
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -637,7 +635,7 @@ where
     }
 
     /// Reset the step count to 0
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -665,7 +663,7 @@ where
     }
 
     /// Activity Recognition
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -700,7 +698,7 @@ where
     ///
     /// -128 (-40.0℃) to
     /// 127 (87.5℃)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -724,7 +722,7 @@ where
     }
 
     /// Chip temperature in degrees celsius with 0.5℃ resolution
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -745,15 +743,15 @@ where
         Ok(f32::from(self.get_raw_temp()?) * 0.5 + 23.0)
     }
 
-    /// Configure how the accelerometer samples, filters and ouputs data 
-    /// 
+    /// Configure how the accelerometer samples, filters and ouputs data
+    ///
     /// - [PowerMode] using [`with_power_mode()`](AccConfigBuilder::with_power_mode)
     /// - [DataSource] for [`get_data()`](BMA400::get_data) and [`get_unscaled_data()`](BMA400::get_unscaled_data) using [`with_reg_dta_src()`](AccConfigBuilder::with_reg_dta_src)
     /// - [OversampleRate] for low power and normal modes using [`with_osr_lp()`](AccConfigBuilder::with_osr_lp) and [`with_osr()`](AccConfigBuilder::with_osr) respectively
     /// - [Filter1Bandwidth] using [`with_filt1_bw()`](AccConfigBuilder::with_filt1_bw)
     /// - [OutputDataRate] using [`with_odr()`](AccConfigBuilder::with_odr)
     /// - [Scale] using [`with_scale()`](AccConfigBuilder::with_scale)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -766,7 +764,7 @@ where
     /// #    ];
     /// # let i2c = Mock::new(&expected);
     /// # let mut bma400 = BMA400::new_i2c(i2c).unwrap();
-    /// // Set the PowerMode to Normal, Scale to 16g 
+    /// // Set the PowerMode to Normal, Scale to 16g
     /// // and low power oversample rate to OSR3
     /// bma400.config_accel()
     ///     .with_power_mode(PowerMode::Normal)
@@ -779,9 +777,9 @@ where
     }
 
     /// Enable or disable interrupts[^except] and set interrupt latch mode
-    /// 
+    ///
     /// [^except]: To enable the Auto-Wakeup Interrupt see [`config_autowkup()`](BMA400::config_autowkup)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -811,7 +809,7 @@ where
     /// - Control the pin electrical behavior using [`with_int1_cfg()`](IntPinConfigBuilder::with_int1_cfg) / [`with_int2_cfg()`](IntPinConfigBuilder::with_int2_cfg)
     ///    - [`PinOutputConfig::PushPull`] High = VDDIO, Low = GND
     ///    - [`PinOutputConfig::OpenDrain`] High = VDDIO, Low = High Impedance
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -837,7 +835,7 @@ where
     }
 
     /// Configure the 1024 byte FIFO Buffer Behavior
-    /// 
+    ///
     /// - Enable / Disable writing data for axes using [`with_axes()`](FifoConfigBuilder::with_axes)
     /// - Enable / Disable 8 bit mode (truncate the 4 least significant bits) to save space in the buffer using [`with_8bit_mode`](FifoConfigBuilder::with_8bit_mode)
     /// - [DataSource] for the FIFO Buffer using [`with_src()`](FifoConfigBuilder::with_src)
@@ -846,7 +844,7 @@ where
     /// - Enable / Disable automatic flush on power mode change using [`with_auto_flush()`](FifoConfigBuilder::with_auto_flush)
     /// - Set the fill threshold for the FIFO watermark interrupt using [`with_watermark_thresh()`](FifoConfigBuilder::with_watermark_thresh)
     /// - Manually Enable / Disable the FIFO read circuit using [`with_read_disabled()`](FifoConfigBuilder::with_read_disabled)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -873,12 +871,12 @@ where
     }
 
     /// Configure Auto Low Power settings
-    /// 
+    ///
     /// - Set the timeout counter for low power mode using [`with_timeout()`](AutoLpConfigBuilder::with_timeout)
     /// - [AutoLPTimeoutTrigger] (trigger and timer reset condition) using [`with_auto_lp_trigger()`](AutoLpConfigBuilder::with_auto_lp_trigger)
     /// - Set Generic Interrupt 1 as a trigger condition for auto low power using [`with_gen1_int_trigger()`](AutoLpConfigBuilder::with_gen1_int_trigger)
     /// - Set Data Ready as a trigger condition for auto low power using [`with_drdy_trigger()`](AutoLpConfigBuilder::with_drdy_trigger)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -903,11 +901,11 @@ where
     }
 
     /// Configure Auto Wake-up settings
-    /// 
+    ///
     /// - Set the length of time between each wake-up using [`with_wakeup_period()`](AutoWakeupConfigBuilder::with_wakeup_period)
     /// - Enable / Disable periodic wakeup using [`with_periodic_wakeup()`](AutoWakeupConfigBuilder::with_periodic_wakeup)
     /// - Enable / Disable wake-up interrupt using [`with_activity_int()`](AutoWakeupConfigBuilder::with_activity_int)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -920,8 +918,8 @@ where
     /// #    ];
     /// # let i2c = Mock::new(&expected);
     /// # let mut bma400 = BMA400::new_i2c(i2c).unwrap();
-    /// // Enable periodic wakeup, auto wakeup on 
-    /// // activity interrupt trigger and set the 
+    /// // Enable periodic wakeup, auto wakeup on
+    /// // activity interrupt trigger and set the
     /// // wakeup period to 500ms
     /// bma400.config_autowkup()
     ///     .with_wakeup_period(1250)
@@ -934,13 +932,13 @@ where
     }
 
     /// Configure Wake-up Interrupt settings
-    /// 
+    ///
     /// - [WakeupIntRefMode] using [`with_ref_mode()`](WakeupIntConfigBuilder::with_ref_mode)
     /// - Set the number of consecutive samples that must satisfy the condition before the interrupt is triggered using [`with_num_samples()`](WakeupIntConfigBuilder::with_num_samples)
     /// - Enable / Disable axes to be evaluated against the condition using [`with_axes()`](WakeupIntConfigBuilder::with_axes)
     /// - Set the interrupt trigger threshold using [`with_threshold()`](WakeupIntConfigBuilder::with_threshold)
     /// - Set the reference acceleration using [`with_ref_accel()`](WakeupIntConfigBuilder::with_ref_accel)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -954,7 +952,7 @@ where
     /// # let i2c = Mock::new(&expected);
     /// # let mut bma400 = BMA400::new_i2c(i2c).unwrap();
     /// // Enable wakeup interrupt for x and y axes w/ a threshold
-    /// // of 256 milli-g (at 4g scale) and automatically update the 
+    /// // of 256 milli-g (at 4g scale) and automatically update the
     /// // reference acceleration once each time the device
     /// // enters low power mode
     /// bma400.config_wkup_int()
@@ -968,13 +966,13 @@ where
     }
 
     /// Configure Orientation Change Interrupt settings
-    /// 
+    ///
     /// - Enable / Disable axes evaluated for the interrupt trigger condition using [`with_axes()`](OrientChgConfigBuilder::with_axes)
     /// - [DataSource] used for evaluating the trigger condition [`with_src()`](OrientChgConfigBuilder::with_src)
     /// - Set the [OrientIntRefMode] (reference acceleration update mode) using [`with_ref_mode()`](OrientChgConfigBuilder::with_ref_mode)
     /// - Set the number of samples that a newly detected orientation must be in effect before the interrupt is triggered with [`with_duration()`](OrientChgConfigBuilder::with_duration)
     /// - Manually set the reference acceleration for the interrupt trigger condition using [`with_ref_accel()`](OrientChgConfigBuilder::with_ref_accel)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -987,7 +985,7 @@ where
     /// #    ];
     /// # let i2c = Mock::new(&expected);
     /// # let mut bma400 = BMA400::new_i2c(i2c).unwrap();
-    /// // Enable orientation change interrupt all axes, automatically 
+    /// // Enable orientation change interrupt all axes, automatically
     /// // update the reference acceleration once each time the device
     /// // enters a new stable orientation with a threshold of 256 milli-g
     /// // (at 4g scale)
@@ -1002,7 +1000,7 @@ where
     }
 
     /// Configure Generic Interrupt 1 settings
-    /// 
+    ///
     /// - Enable / Disable axes evaluated for the interrupt trigger condition using [`with_axes()`](GenIntConfigBuilder::with_axes)
     /// - [DataSource] used for evaluating the trigger condition using [`with_src()`](GenIntConfigBuilder::with_src)
     /// - Set the [GenIntRefMode] (reference acceleration update mode) using [`with_ref_mode()`](GenIntConfigBuilder::with_ref_mode)
@@ -1012,7 +1010,7 @@ where
     /// - Set the interrupt trigger threshold using [`with_threshold()`](GenIntConfigBuilder::with_threshold)
     /// - Set the number of cycles that the interrupt condition must be true before the interrupt triggers using [`with_duration()`](GenIntConfigBuilder::with_duration)
     /// - Manually set the reference acceleration for the interrupt trigger condition using [`with_ref_accel()`](GenIntConfigBuilder::with_ref_accel)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -1044,7 +1042,7 @@ where
     }
 
     /// Configure Generic Interrupt 2 settings
-    /// 
+    ///
     /// - Enable / Disable axes evaluated for the interrupt trigger condition using [`with_axes()`](GenIntConfigBuilder::with_axes)
     /// - [DataSource] used for evaluating the trigger condition using [`with_src()`](GenIntConfigBuilder::with_src)
     /// - Set the [GenIntRefMode] (reference acceleration update mode) using [`with_ref_mode()`](GenIntConfigBuilder::with_ref_mode)
@@ -1054,7 +1052,7 @@ where
     /// - Set the interrupt trigger threshold using [`with_threshold()`](GenIntConfigBuilder::with_threshold)
     /// - Set the number of cycles that the interrupt condition must be true before the interrupt triggers using [`with_duration()`](GenIntConfigBuilder::with_duration)
     /// - Manually set the reference acceleration for the interrupt trigger condition using [`with_ref_accel()`](GenIntConfigBuilder::with_ref_accel)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -1086,12 +1084,12 @@ where
     }
 
     /// Configure Activity Change Interrupt settings
-    /// 
+    ///
     /// - Set the interrupt trigger threshold using [`with_threshold()`](ActChgConfigBuilder::with_threshold)
     /// - Enable / Disable the axes evaluated for the interrupt trigger condition using [`with_axes()`](ActChgConfigBuilder::with_axes)
     /// - [DataSource] used for evaluating the trigger condition using [`with_src()`](ActChgConfigBuilder::with_src)
     /// - [ActChgObsPeriod] (number of samples) using [`with_obs_period()`](ActChgConfigBuilder::with_obs_period)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -1120,13 +1118,13 @@ where
     }
 
     /// Configure Advanced Tap Interrupt Settings
-    /// 
+    ///
     /// - Set the axis evaluated for the interrupt trigger condition using [`with_axis()`](TapConfigBuilder::with_axis)
     /// - [TapSensitivity] using [`with_sensitivity()`](TapConfigBuilder::with_sensitivity)
     /// - [MinTapDuration] using [`with_min_duration_btn_taps()`](TapConfigBuilder::with_min_duration_btn_taps)
     /// - [DoubleTapDuration] using [`with_max_double_tap_window()`](TapConfigBuilder::with_max_double_tap_window)
     /// - [MaxTapDuration] using [`with_max_tap_duration()`](TapConfigBuilder::with_max_tap_duration)
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use embedded_hal_mock::i2c::{Mock, Transaction};
@@ -1157,8 +1155,10 @@ where
     /// This will disable all interrupts and FIFO write for the duration
     ///
     /// See [p.48 of the datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bma400-ds000.pdf#page=48)
-    pub fn perform_self_test<Timer: DelayMs<u8>>(&mut self, timer: &mut Timer) -> Result<(), BMA400Error<InterfaceError, PinError>> {
-
+    pub fn perform_self_test<Timer: DelayNs>(
+        &mut self,
+        timer: &mut Timer,
+    ) -> Result<(), BMA400Error<InterfaceError, PinError>> {
         // Disable interrupts, set accelerometer test config
         self.config.setup_self_test(&mut self.interface)?;
 
@@ -1166,7 +1166,8 @@ where
         timer.delay_ms(2);
 
         // Write positive test parameters to SelfTest register
-        self.interface.write_register(SelfTest::from_bits_truncate(0x07))?;
+        self.interface
+            .write_register(SelfTest::from_bits_truncate(0x07))?;
 
         // Wait 50ms
         timer.delay_ms(50);
@@ -1175,7 +1176,8 @@ where
         let m_pos = self.get_unscaled_data()?;
 
         // Write negative test parameters to SelfTest register
-        self.interface.write_register(SelfTest::from_bits_truncate(0x0F))?;
+        self.interface
+            .write_register(SelfTest::from_bits_truncate(0x0F))?;
 
         // Wait 50ms
         timer.delay_ms(50);
@@ -1223,14 +1225,8 @@ where
 mod tests {
     use super::*;
     use crate::{
-        interface::{
-            ReadFromRegister,
-            WriteToRegister,
-        },
-        registers::{
-            ReadReg,
-            ConfigReg,
-        },
+        interface::{ReadFromRegister, WriteToRegister},
+        registers::{ConfigReg, ReadReg},
         BMA400,
     };
     pub struct NoOpInterface;
@@ -1239,7 +1235,11 @@ mod tests {
     impl ReadFromRegister for NoOpInterface {
         type Error = BMA400Error<NoOpError, ()>;
 
-        fn read_register<T: ReadReg>(&mut self, _register: T, _buffer: &mut [u8]) -> Result<(), Self::Error> {
+        fn read_register<T: ReadReg>(
+            &mut self,
+            _register: T,
+            _buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
             Ok(())
         }
     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,5 +1,5 @@
 use crate::{
-    hal::{digital::OutputPin, spi::SpiBus},
+    hal::{digital::OutputPin, spi::SpiDevice},
     interface::{ReadFromRegister, WriteToRegister},
     registers::{ChipId, ConfigReg, InterfaceConfig, ReadReg},
     BMA400Error, Config, BMA400,
@@ -23,7 +23,7 @@ impl<SPI, CSBPin> SPIInterface<SPI, CSBPin> {
 
 impl<SPI, CSBPin, InterfaceError, PinError> WriteToRegister for SPIInterface<SPI, CSBPin>
 where
-    SPI: SpiBus<u8, Error = InterfaceError>,
+    SPI: SpiDevice<u8, Error = InterfaceError>,
     CSBPin: OutputPin<Error = PinError>,
 {
     type Error = BMA400Error<InterfaceError, PinError>;
@@ -44,7 +44,7 @@ where
 
 impl<SPI, CSBPin, InterfaceError, PinError> ReadFromRegister for SPIInterface<SPI, CSBPin>
 where
-    SPI: SpiBus<u8, Error = InterfaceError>,
+    SPI: SpiDevice<u8, Error = InterfaceError>,
     CSBPin: OutputPin<Error = PinError>,
 {
     type Error = BMA400Error<InterfaceError, PinError>;
@@ -69,7 +69,7 @@ where
 
 impl<SPI, CSBPin, InterfaceError, PinError> BMA400<SPIInterface<SPI, CSBPin>>
 where
-    SPI: SpiBus<u8, Error = InterfaceError>,
+    SPI: SpiDevice<u8, Error = InterfaceError>,
     CSBPin: OutputPin<Error = PinError>,
 {
     /// Create a new instance of the BMA400 using 4-wire SPI


### PR DESCRIPTION
This crate uses an out-of-date version of `embedded-hal`, which means that extremely useful features (like the bus sharing from `embedded-hal-bus`) cannot be used with this crate. This PR mogrates `bma400` to `embedded-hal` v1.0.0.

The main migration currently seems complete, but the test suite will be a bit of a pain, as `embedded-hal-mock` now requires tests to call `.done()` on each mock (https://github.com/dbrgn/embedded-hal-mock/issues/34).

PS: Thanks for the great crate!